### PR TITLE
always get newest saved record if multiple exist

### DIFF
--- a/django-src/shinyadmin/core/models.py
+++ b/django-src/shinyadmin/core/models.py
@@ -50,3 +50,4 @@ class DamsMCDARunPreference(models.Model):
         verbose_name = 'Run Preference'
         verbose_name_plural = 'Run Preferences'
         unique_together = ('group', 'user')
+        ordering = ('-pk',)

--- a/src/dams_mcda/www/dams_mcda.js
+++ b/src/dams_mcda/www/dams_mcda.js
@@ -135,7 +135,7 @@ function saveRawJsonScores(message){
 		dataType:'json',
 		data: getParams
 	}).done(function(data){
-		if (data.length == 1){
+		if (data.length > 1){
 			// UPDATE already existing
 			$.ajax({
 				url: "/core/api/preference/"+ data[0].id +"/",


### PR DESCRIPTION
should only happen when save-breaking changes are made such as another dam added or dam name changed

relates to issue #159 